### PR TITLE
Build both Doxygen and Sphinx in the Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: generic
 python:
   - 3.6
 
-install: 
+install:
   - pip install --user sphinx  # sphinx_rtd_theme
     # pypi's sphinx_rtd_theme is outdated. Internet recommends using current
     # master. Note: at some point, it will be OK to add `sphinx_rtd_theme` to
@@ -26,7 +26,7 @@ addons:
 deploy:
   provider: pages
   target-branch: gh-pages
-  local-dir: docs/build
+  local-dir: docs/webroot
   skip-cleanup: true
   github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
   keep-history: true

--- a/build_and_deploy.sh
+++ b/build_and_deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 set -e # Exit with nonzero exit code if anything fails
 
 # Then we build and deploy the sphinx / doxygen documentation
@@ -16,43 +16,5 @@ fi
 #SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
 #SHA=`git rev-parse --verify HEAD`
 
-# Change working directory to /docs
-cd docs    # ..................................... now we're in /docs 
-
-
-############################# DOXYGEN  ########################################
-
-
-cd doxygen # ..................................... now we're in /docs/doxygen
-
-# create temporary clone of MFiX-Exa SOURCE_BRANCH
-git clone https://gitlab-ci-token:$GITLAB_TOKEN@mfix.netl.doe.gov/gitlab/exa/mfix.git
-
-# build the Doxygen documentation
-doxygen doxygen.conf
-
-cd ..      # ..................................... now we're in /docs
-
-# move it to the deploy directory: /docs/build
-mkdir build
-mv doxygen/html build/doxygen
-
-
-############################# SPHINX   ########################################
-
-
-# now do sphinx
-make html
-cd build   # ..................................... now we're in /docs/build
-mv html docs_html
-
-
-############################# WEB SERVER STUFF ################################
-
-
-# Sphinx is set up to treat build/html (and by mv, build/docs_html) as the
-# webroot. Hence the .nojekyll file is in the wrong place
-mv docs_html/.nojekyll .
-
-# PWD is currently /docs/build, we want to move /docs/webroot into /docs/build
-mv ../webroot/* .
+# build Doxygen docs and Sphinx docs
+make -C docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,9 +6,14 @@ SPHINXOPTS    =
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = amrex
 SOURCEDIR     = source
-BUILDDIR      = build
+BUILDDIR      = webroot
 
-# Put it first so that "make" without argument is like "make help".
+all: html webroot/doxygen
+	mv webroot/html webroot/docs_html
+# Sphinx is set up to treat its build directory as the webroot, hence the
+# .nojekyll file is in the wrong place
+	mv webroot/docs_html/.nojekyll webroot
+
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
@@ -18,3 +23,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+webroot/doxygen:
+	git clone https://gitlab-ci-token:$GITLAB_TOKEN@mfix.netl.doe.gov/gitlab/exa/mfix.git doxygen/mfix
+	cd doxygen && doxygen doxygen.conf
+	mv doxygen/html $@


### PR DESCRIPTION
Using the Makefile to build doxygen docs is equivalent, and easier to read because there are fewer cd's.

Using `webroot` as the build target directory instead of `build` is also more direct.